### PR TITLE
fix build error and add easy to use overview script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# runs the isatomic test and summarizes into a table without details to stdout
+
+set -eu
+
+cmake -B build/ -S . -DCMAKE_BUILD_TYPE=Release >/dev/null 2>&1
+cmake --build build >/dev/null
+prog=build/isatomic
+
+cpu=$(cat /proc/cpuinfo |grep "model name" |head -n1 |cut -f2 -d:)
+
+
+for T in 128 128u 128s 256 256u 256s 512 512s; do
+    if $prog -t $T>/dev/null; then
+	printf '%-5s %s\n' $T OK
+    else
+	printf '%-5s %s\n' $T FAILED
+    fi
+done
+
+# show the avx flags
+echo "=============================="
+echo "cpu: $cpu"
+echo "avx flags:"
+grep ^flags /proc/cpuinfo  |head -n1 |cut -f2 -d: |xargs -n1 echo |grep avx |sort

--- a/src/isatomic.cpp
+++ b/src/isatomic.cpp
@@ -1,6 +1,7 @@
 // © 2020 Erik Rigtorp <erik@rigtorp.se>
 // SPDX-License-Identifier: MIT
 
+#include <array>
 #include <atomic>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
Following the request on https://rigtorp.se/isatomic/  I test ran this on two systems with avx512:

```
128   OK
128u  OK
128s  FAILED
256   OK
256u  OK
256s  FAILED
512   OK
512s  FAILED
==============================
cpu:  Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz
avx flags:
avx
avx2
avx512_bitalg
avx512bw
avx512cd
avx512dq
avx512f
avx512ifma
avx512vbmi
avx512_vbmi2
avx512vl
avx512_vnni
avx512_vpopcntdq
```

```
128   OK
128u  FAILED
128s  FAILED
256   OK
256u  FAILED
256s  FAILED
512   FAILED
512s  FAILED
==============================
cpu:  AMD Ryzen 9 7950X3D 16-Core Processor
avx flags:
avx
avx2
avx512_bf16
avx512_bitalg
avx512bw
avx512cd
avx512dq
avx512f
avx512ifma
avx512vbmi
avx512_vbmi2
avx512vl
avx512_vnni
avx512_vpopcntdq

```
